### PR TITLE
ADD: alias command attribute

### DIFF
--- a/TalkerNode.js
+++ b/TalkerNode.js
@@ -461,36 +461,42 @@ function setCmdRank(command, rank) {
  */
 function findCommand(socket, command) {
     var c = command;
-    var userRank = socket.db.rank;
+	var userRank = socket.db.rank;
+	// hierarchy: direct match > weighted partial match > alias direct match
     if(commands[c] && userRank >= getCmdRank(c)) {
-	return [commands[c]];
+		// direct match
+		return [commands[c]];
     } else {
-	// when we have more than one possible command, we
-	// choose the most heavier from the ones with lower
-	// getCmdRank
-	var results = [];
-	var weigth = 0;
-	var rank = ranks.list.length - 1;
-	for (var cmd in commands) {
-	    if(cmd.substr(0, c.length) == c && userRank >= getCmdRank(cmd)) {
-		var cweigth = 0;
-		if (typeof commands[cmd].weigth !== 'undefined')
-		    cweigth = commands[cmd].weigth;
-		if (getCmdRank(cmd) < rank) {
-		    rank = getCmdRank(cmd);
-		    weigth = cweigth;
-		    results = [commands[cmd]];
-		} else if (getCmdRank(cmd) === rank) {
-		    if (cweigth > weigth) {
-			weigth = commands[cmd].weigth;
-			results = [commands[cmd]];
-		    } else if (cweigth === weigth) {
-			results.push(commands[cmd]);
-		    }
+		// when we have more than one possible command, we
+		// choose the most heavier from the ones with lower
+		// getCmdRank
+		var results = [];
+		var weigth = 0;
+		var rank = ranks.list.length - 1;
+		for (var cmd in commands) {
+			if(cmd.substr(0, c.length) == c && userRank >= getCmdRank(cmd)) {
+				// partial match
+				var cweigth = 0;
+				if (typeof commands[cmd].weigth !== 'undefined')
+					cweigth = commands[cmd].weigth;
+				if (getCmdRank(cmd) < rank) {
+					rank = getCmdRank(cmd);
+					weigth = cweigth;
+					results = [commands[cmd]];
+				} else if (getCmdRank(cmd) === rank) {
+					if (cweigth > weigth) {
+						weigth = commands[cmd].weigth;
+						results = [commands[cmd]];
+					} else if (cweigth === weigth) {
+						results.push(commands[cmd]);
+					}
+				}
+			} else if (commands[cmd].alias != 'undefined' && commands[cmd] != "" && commands[cmd].alias == c) {
+				// alias direct match
+				return [commands[cmd]]
+			}
 		}
-	    }
-	}
-	return results;
+		return results;
     }
 }
 

--- a/commands/template.js
+++ b/commands/template.js
@@ -1,5 +1,6 @@
 exports.command = {
 	name: "template", 			// Name of command to be executed (Max 10 chars)
+	alias: "ctemplate",			// Alias for the command (partial match not supported; Max 10 chars)
 	autoload: false,			// Should the command be autoloaded at startup
 	unloadable: true,			// Can the command be unloaded dynamically
 	min_rank: 0,				// Minimum rank to use to execute the command


### PR DESCRIPTION
A new attribute was added to the command definition: alias. Although optional, it should be included in the command definition for standardization.

findCommand() now searches for commands following the hierarchy "direct match > weighted partial match > alias direct match". The command alias is always the last to be searched for and only allows for a direct match. Commands may only have one defined alias.