### PR TITLE
Added the ability to have aliases

### DIFF
--- a/commands/color.js
+++ b/commands/color.js
@@ -1,6 +1,6 @@
 exports.command = {
 	name: "color",
-	alias: "colour",
+	aka: "colour",
 	autoload: true,
 	unloadable: false,
 	min_rank: 1,

--- a/commands/emote.js
+++ b/commands/emote.js
@@ -1,11 +1,12 @@
 exports.command = {
-	name: "emote", 			
+	name: "emote",
+	alias: [':', ';'],
 	autoload: true,			
 	unloadable: false,
 	min_rank: 0,
 	display: "lets you pose something, as if you were acting",
 	help: "Lets you pose something, as if you were acting.",
-	usage: ".emote <text>",
+	usage: [".emote <text>", ":<text>", ";<text>"],
 	weigth: 10,
 
 	execute: function(socket, command, command_access) {

--- a/commands/file.js
+++ b/commands/file.js
@@ -5,7 +5,7 @@ exports.command = {
 	min_rank: 0,
 	display: "Show a list of files, or a the content of one",
 	help: "There can be a number of files available for you to read. This is the command used to either list or read them.",
-	usage: ".file, .file <filename>",
+	usage: ".file [<filename>]",
 
 	execute: function(socket, command, command_access) {
 

--- a/commands/help.js
+++ b/commands/help.js
@@ -1,4 +1,5 @@
 var formatters = require('../utils/formatters.js');
+const chalk = require("chalk");
 
 exports.command = {
 	name: "help",
@@ -7,7 +8,7 @@ exports.command = {
 	min_rank: 0,
 	display: "Shows all commands or information about one of them.",
 	help: "Shows you this list of commands or detailed help for a particular command.",
-	usage: ".help, .help <command>",
+	usage: ".help [<command>]",
 
 	execute: function(socket, command, command_access) {
 
@@ -29,19 +30,29 @@ exports.command = {
 					if (l == command_access.getCmdRank(c)) {
 						var cmd = command_access.commands[c].name;
 						var desc = command_access.commands[c].display;
+						var aliases = '';
+						if ('alias' in command_access.commands[c]) {
+							aliases = ' (';
+							if (command_access.commands[c].alias instanceof Array) {
+								aliases += command_access.commands[c].alias.join('');
+							} else {
+								aliases += command_access.commands[c].alias;
+							}
+							aliases += ')';
+						}
 
 						if(cmd.length > 10) {
 							cmd = cmd.substr(0, 10);
 						}
 
-						if(desc.length > 60) {
-							desc = desc.substr(0, 57) + "...";
+						if(desc.length > 58) {
+							desc = desc.substr(0, 55) + "...";
 						}
 
-						command_access.sendData(socket, chalk.blue("| " + chalk.bold("." +  cmd) +
-							Array(11 - cmd.length).join(' ') + chalk.yellow(" - ") +
-							chalk.green(desc) + Array(62 - desc.length).join(' ') +
-							" |\r\n"));
+						command_access.sendData(socket, chalk.blue("| " + chalk.bold("." + cmd + aliases)
+							+ Array((13 - aliases.length) - cmd.length).join(' ')
+							+ chalk.yellow(" - ") + chalk.green(desc)
+							+ Array(60 - desc.length).join(' ') + " |\r\n"));
 					}
 				}
 			}
@@ -66,7 +77,14 @@ exports.command = {
 			var command_to_show = commands[0];
 
 			command_access.sendData(socket, chalk.bold("Command : ") + command_to_show.name + "\r\n");
-			command_access.sendData(socket, chalk.bold("Usage   : ") + command_to_show.usage + "\r\n");
+			if (command_to_show.usage instanceof Array) {
+				command_to_show.usage.map((usage, index) => {
+					let prefix = !index ? 'Usage   : ' : '        : ';
+					command_access.sendData(socket, chalk.bold(prefix) + usage + "\r\n");
+				});
+			} else {
+				command_access.sendData(socket, chalk.bold("Usage   : ") + command_to_show.usage + "\r\n");
+			}
 			command_access.sendData(socket, "" + "\r\n");
 			command_access.sendData(socket, formatters.text_wrap(command_to_show.help) + "\r\n");
 			command_access.sendData(socket, "" + "\r\n");

--- a/commands/semote.js
+++ b/commands/semote.js
@@ -1,11 +1,12 @@
 exports.command = {
-	name: "semote", 			
+	name: "semote",
+	alias: ['&', '!'],
 	autoload: true,			
 	unloadable: false,
 	min_rank: 2,
 	display: "pose something for everyone (even those not here) to see",
 	help: "Lets you pose something, as if you were acting, for everyone (even those not here) to see.",
-	usage: ".semote <text>",
+	usage: [".semote <text>", "&<text>", "!<text>"],
 
 	execute: function(socket, command, command_access) {
 		var chalk = require('chalk');

--- a/commands/shout.js
+++ b/commands/shout.js
@@ -1,11 +1,12 @@
 exports.command = {
-	name: "shout", 			
+	name: "shout",
+	alias: '[',
 	autoload: true,			
 	unloadable: false,
 	min_rank: 2,
 	display: "you shout, everyone listens, no matter where they are",
 	help: "You shout, everyone listens, even if they're not in the same place as you!",
-	usage: ".shout <text>",
+	usage: [".shout <text>", "[<text>"],
 
 	execute: function(socket, command, command_access) {
 		var chalk = require('chalk');

--- a/commands/template.js
+++ b/commands/template.js
@@ -1,6 +1,6 @@
 exports.command = {
 	name: "template", 			// Name of command to be executed (Max 10 chars)
-	alias: "ctemplate",			// Alias for the command (partial match not supported; Max 10 chars)
+	aka: "ctemplate",			// Alias for the command (partial match not supported; Max 10 chars)
 	autoload: false,			// Should the command be autoloaded at startup
 	unloadable: true,			// Can the command be unloaded dynamically
 	min_rank: 0,				// Minimum rank to use to execute the command

--- a/commands/who.js
+++ b/commands/who.js
@@ -1,11 +1,12 @@
 exports.command = {
-	name: "who", 			
+	name: "who",
+	alias: "@",
 	autoload: true,			
 	unloadable: false,
 	min_rank: 0,
 	display: "lets you know who is connected in the talker at this moment",
 	help: "Lets you know who is connected in the talker at this moment.",
-	usage: ".who",
+	usage: [".who", "@"],
 	weigth: 10,
 
 	// helper functions that should probably be global, instead of stuck here in the command file


### PR DESCRIPTION
Possible solution for #114 

* Changed the existing `alias` property to `aka`
* Added `alias` as either a string or array (if multiple aliases) to commands, matching the amnuts aliases for parity
* Updated .help output to include aliases
* Updated .help so that command usage could be an array or string, and if it's an array it will output on multiple lines
* Tweaked some usage text