### PR TITLE
Fixes #103

### DIFF
--- a/TalkerNode.js
+++ b/TalkerNode.js
@@ -757,14 +757,24 @@ function command_utility() {
 	    // that case, an user can type '.tell mr hello', meaning '.tell MrMe
 	    // hello'. On that case, 'getAproxOnlineUser' should be used.
 	    getAproxOnlineUser: function getOnlineUser(name) {
-		if (this.getOnlineUser(name) !== false) return [this.getOnlineUser(name)];
-		var possibilities = [];
-		for (var i = 0; i < sockets.length; i++) {
-		    if (name.toLowerCase() === sockets[i].username.toLowerCase().substr(0,name.length) && sockets[i].loggedin && (name.length < sockets[i].username.length))
-			possibilities.push(sockets[i]);
-		}
-		return possibilities;
+			if (this.getOnlineUser(name) !== false) return [this.getOnlineUser(name)];
+			var possibilities = [];
+			for (var i = 0; i < sockets.length; i++) {
+				if (name.toLowerCase() === sockets[i].username.toLowerCase().substr(0,name.length) && sockets[i].loggedin && (name.length < sockets[i].username.length))
+				possibilities.push(sockets[i]);
+			}
+			return possibilities;
 	    },
+
+		// As with `getAproxOnlineUser` except it will filter out the excluded
+		// user from the list (typically the person running the command)
+		getAproxOnlineUserExcluding: function getOnlineUser(name, excludeName, onlyIfMultiple = false) {
+			let possibilities = this.getAproxOnlineUser(name);
+			if (!onlyIfMultiple || (onlyIfMultiple && possibilities.length > 1)) {
+				possibilities = possibilities.filter(user => user.username.toLowerCase() !== excludeName.toLowerCase());
+			}
+			return possibilities;
+		},
 
         // returns the user object, in all its db glory
         // TODO: Let's give just a subset of data from the user, OK? I mean, we

--- a/commands/shoutto.js
+++ b/commands/shoutto.js
@@ -1,0 +1,42 @@
+const chalk = require("chalk");
+exports.command = {
+	name: "shoutto",
+	aka: "sto",
+	alias: "]",
+	autoload: true,
+	unloadable: false,
+	min_rank: 2,
+	display: "you shout to someone, everyone logged in hears",
+	help: "You shout to someone and everyone can hear, even if they're not in the same place as you!",
+	usage: [".shoutto <user> <text>", ".sto <user> <text>", "] <user> <text>"],
+
+	execute: function(socket, command, command_access) {
+		let chalk = require('chalk');
+		let to = command.split(' ')[0];
+		let message = command.split(' ').slice(1).join(' ');
+
+		if ((typeof to === 'undefined') || (typeof message === 'undefined') || to.length < 1 || message.length < 1) {
+			return command_access.sendData(socket, chalk.yellow(":: ") + "You have to use it this way:" + chalk.yellow(" .shoutto <user> <text>\r\n"));
+		}
+
+		let possibleUsers = command_access.getAproxOnlineUserExcluding(to, socket.username, true);
+		if (!possibleUsers.length) {
+			return command_access.sendData(socket, chalk.red(":: ") + `You cannot see ${to}, so you cannot shout anything to them!\r\n`);
+		} else if (possibleUsers.length === 1) {
+			if (socket.username.toLowerCase() === possibleUsers[0].username.toLowerCase()) {
+				return command_access.sendData(socket, chalk.red(":: ") + "Talking to yourself is the first sign of madness.\r\n");
+			}
+			command_access.allButMe(socket,function(me, to) {
+				to.write(`${chalk.bold('!')} ${me.username} ${chalk.bold('shouts')} to ${chalk.bold(possibleUsers[0].username)}: ${message}\r\n`);
+			});
+			command_access.sendData(socket, `${chalk.bold('!')} You ${chalk.bold('shout')} to ${chalk.bold(possibleUsers[0].username)}: ${message}\r\n`);
+		} else {
+			let possibilities = "";
+			for (let p = 0; p < possibleUsers.length - 1; p++) {
+				possibilities += chalk.bold(possibleUsers[p].username) + ", ";
+			}
+			possibilities += chalk.bold(possibleUsers[possibleUsers.length - 1].username);
+			command_access.sendData(socket, chalk.yellow(":: ") + "Be more explicit: whom do you want to say to ("+possibilities+")?\r\n");
+		}
+	}
+}


### PR DESCRIPTION
This adds the `shoutto` command.  A helper function was also added to the `command_access` object in order to make it easier to get an approx list of users that can exclude a particular name (such as the person running the command),

![image](https://user-images.githubusercontent.com/684421/136624087-05a9cad1-c48c-4fb8-9778-2cdc3a57d539.png)
